### PR TITLE
envPath processing mistake

### DIFF
--- a/ProjectTemplates/ReferenceProject/Startup.cs
+++ b/ProjectTemplates/ReferenceProject/Startup.cs
@@ -36,7 +36,7 @@ namespace ReferenceProject
             var envPath = Path.Combine(env.ContentRootPath, ".env");
             if (File.Exists(envPath))
             {
-                DotNetEnv.Env.Load();
+                DotNetEnv.Env.Load(envPath);
             }
 
             // See: https://github.com/drwatson1/AspNet-Core-REST-Service/wiki#content-formatting


### PR DESCRIPTION
The variable envPath is constructed but never used. Environment variables might not be loaded properly.